### PR TITLE
fix: conflict with html-webpack-plugin

### DIFF
--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -10,6 +10,9 @@ export const unpluginFactory: UnpluginFactory<UserOptions | undefined> = (
   return {
     name: 'unplugin-preprocessor-directives',
     enforce: 'pre',
+    transformInclude(id) {
+      return ctx.filter(id)
+    },
     transform: (code, id) => ctx.transform(code, id),
     vite: {
       configResolved(config) {


### PR DESCRIPTION
When I using this plugin with vue-cli5, `vue-cli-service serve` and `vue-cli-service build` will throw error:
```
Error: Child compilation failed:
  Module parse failed: Unexpected token (1:0)
  File was processed with these loaders:
   * ./node_modules/.pnpm/html-webpack-plugin@5.5.3_webpack@5.88.2/node_modules/html-webpack-plugin/lib/loader.js
   * ./node_modules/.pnpm/unplugin@1.5.0/node_modules/unplugin/dist/webpack/loaders/transform.js
  You may need an additional loader to handle the result of these loaders.
  > <!DOCTYPE html>
  | <html lang="">
  |   <head>
```
I found html-webpack-plugin/lib/loader.js will check [if there is any other loader](https://github.com/jantimon/html-webpack-plugin/blob/fe231d3d3d256c2bb904b9e0f3f1e7aa67d7f3cd/lib/loader.js#L11), if exists it will return unmodified source, which cause error.
After some dig, I found add transformInclude hook and `/\.html/` to plugin exclude config, unplugin will not create the loader which conflict with html-webpack-plugin and solve issue.
